### PR TITLE
Update engines.js

### DIFF
--- a/src/engines.js
+++ b/src/engines.js
@@ -5,7 +5,7 @@
 const google = {
   needkey: true,
   fetch: ({ key, from, to, text }) => [
-    `https://translation.googleapis.com/language/translate/v2?key=${key}&source=${from}&target=${to}&q=${encodeURIComponent(text)}`,
+    `https://translation.googleapis.com/language/translate/v2?key=${key}&format=text&source=${from}&target=${to}&q=${encodeURIComponent(text)}`,
     { method: 'POST' }
   ],
   parse: res => res.json().then(body => {


### PR DESCRIPTION
Added format=text to google translation query (default format is html).. so whitespaces and new lines are prevented when translating multi-line text,  closes #13 