### PR TITLE
Handling for traditional Chinese

### DIFF
--- a/src/languages/iso.js
+++ b/src/languages/iso.js
@@ -182,5 +182,6 @@ export default {
   yid: "yi",
   yor: "yo",
   zha: "za",
+  zhtw: "zh-tw"
   zul: "zu",
 };

--- a/src/languages/names.js
+++ b/src/languages/names.js
@@ -31,6 +31,7 @@ export default {
   chamorro: "ch",
   chechen: "ce",
   chinese: "zh",
+  "traditional chinese": "zh-tw",
   "church slavic": "cu",
   "old slavonic": "cu",
   "church slavonic": "cu",


### PR DESCRIPTION
Adding support for traditional Chinese, I described in more detail regarding this language "zh-tw" in this issue:
https://github.com/franciscop/translate/issues/51

Not all translation engines support it. For example, Yandex does not support it.
But Google Translate does support it.
I think that this package should allow "zh-tw" at least to support the engines that allow it.

I verified the changes work as expected, let me know if any other code change is needed, thanks!