### PR TITLE
Change google translate parameters character escape api

### DIFF
--- a/src/engines/google.js
+++ b/src/engines/google.js
@@ -2,7 +2,7 @@ const base = "https://translate.googleapis.com/translate_a/single";
 
 export default {
   fetch: ({ key, from, to, text }) => [
-    `${base}?client=gtx&sl=${from}&tl=${to}&dt=t&q=${encodeURI(text)}`,
+    `${base}?client=gtx&sl=${from}&tl=${to}&dt=t&q=${encodeURIComponent(text)}`,
   ],
   parse: (res) =>
     res.json().then((body) => {


### PR DESCRIPTION
**`; / ? : @ & = + $ , #`** these characters can only be escaped by `encodeURIComponent()`